### PR TITLE
Added missing aphostophe (') in ngrw Ultisnip

### DIFF
--- a/UltiSnips/coffee/angular_coffee.snippets
+++ b/UltiSnips/coffee/angular_coffee.snippets
@@ -55,7 +55,7 @@ endsnippet
 snippet ngrw "Defines a when condition of an AngularJS route."
 $routeProvider.when '${1:url}',
   templateUrl: '${2:templateUrl}' 
-  controller: '${3:controller}
+  controller: '${3:controller}'
 $0
 endsnippet
 


### PR DESCRIPTION
A single aphostrophe was missing in ngrw Ultisnip.
