### PR TITLE
Fixed spaces to one tab space

### DIFF
--- a/snippets/html/angular_html.snippets
+++ b/snippets/html/angular_html.snippets
@@ -25,8 +25,8 @@ snippet ngb
 	{{${1:binding}}}${2}
 # Bind a view to a model
 snippet ngm
-  ng-model="${1:model}"
+	ng-model="${1:model}"
 # Disable a form element
 snippet ngd 
-  ng-disabled="${1:model}"
+	ng-disabled="${1:model}"
 


### PR DESCRIPTION
The current file creates error with UltiSnips because snipMate snippet needs to have one tab space before starting.
