### PR TITLE
Add smart ngdoc comment snippets, python methods

### DIFF
--- a/UltiSnips/javascript/angular_js.snippets
+++ b/UltiSnips/javascript/angular_js.snippets
@@ -254,7 +254,7 @@ snippet /m "NGDoc Method" !b
  * @ngdoc
  * @methodOf ${1:`!p get_ng_component_of(snip)`}
  * @name $1#${2:name}
- * @description ${0:\`$2\` is a method to...}
+ * @description ${0:\`$2\` is a method to}
  */
 endsnippet
 

--- a/UltiSnips/javascript/angular_js.snippets
+++ b/UltiSnips/javascript/angular_js.snippets
@@ -1,20 +1,50 @@
-snippet ngc "Define a new Angular Controller. You can change the controller name and parameters."
-angular.module('`!p
-f = open(fn, 'r').read()
+global !p
+import uuid
+import re
 
-# Regex to find module name
-mod = re.compile('angular.module\((?:\'|,")(.*?)(?:\'|")')
+mod_re = re.compile('angular.module\(["\']*(.*?)["\'\),]')
+type_re = re.compile('\.(controller|directive|service|factory|provider|value)\(')
+component_re = re.compile('\.(?:controller|directive|service|factory|provider)\(["\'](.*?)["\']')
+DEFAULT_NAME = 'appName'
+DEFAULT_TYPE_NAME = 'type'
+DEFAULT_COMPONENT_NAME = 'componentName'
+READ_BYTES=400
 
-matches = mod.findall(f)
+def bufText():
+	return '\n'.join(vim.current.window.buffer[:2])
 
-if len(matches):
-	snip.rv = matches[0]
-else:
-	snip.rv = "moduleName"
-`').controller('${1:controllerName}', function(${2:$scope}){
-	${0:$scope.awesomeThings = ['vim', 'ultisnips', 'python'];}
-});
-endsnippet
+def get_ng_component_of(snip):
+    text = bufText()
+    get_ng_module(snip, text=text)
+    snip.rv += '.'
+    get_ng_type(snip, text=text)
+    snip.rv += ':'
+    get_ng_component(snip, text=text)
+
+def get_ng_type(snip, **kwargs):
+    text = kwargs.get('text', bufText())
+    res = type_re.findall(text)
+    if len(res) > 0:
+        snip.rv += res[0]
+    else:
+        snip.rv += DEFAULT_TYPE_NAME
+
+def get_ng_component(snip, **kwargs):
+    text = kwargs.get('text', bufText())
+    res = component_re.findall(text)
+    if len(res) > 0:
+        snip.rv += res[0]
+    else:
+        snip.rv += DEFAULT_COMPONENT_NAME
+
+def get_ng_module(snip, **kwargs):
+    text = kwargs.get('text', bufText())
+    res = mod_re.findall(text)
+    if len(res) > 0:
+        snip.rv += res[0]
+    else:
+        snip.rv += DEFAULT_NAME
+endglobal
 
 snippet ngfor "angular.foreach loop"
 angular.forEach(${1:iterateOver}, function(value, key) {
@@ -193,20 +223,49 @@ $http.get('${1:/uri}'${3:, ${2:query}})
 	})
 endsnippet
 
-# snippet /meth "Method" !b
-# `!p
-# f = open(fn, 'r').read()
+snippet $iget "Injector Get" !b
+${1:variable} = $injector.get('${2:$1}');
+endsnippet
 
-# # Regex to find module name
-# mod = re.compile('angular.module\((?:\'|,")(.*?)(?:\'|")')
+snippet /s "NGDoc service" !b
+/**
+ * @ngdoc service
+ * @name ${1:`!p get_ng_module(snip)`}.service:${2:serviceName}
+ * @description ${0: $2 is a service to do $2}
+ */
+endsnippet
 
-# matches = mod.findall(f)
+snippet /c "NGDoc service" !b
+/**
+ * @ngdoc controller
+ * @name ${1:`!p get_ng_module(snip)`}.controller:${2:controllerName}
+ * @description ${0: $2 is a controller to do $2}
+ */
+endsnippet
 
-# if len(matches):
-# 	snip.rv = matches[0]
-# else:
-# 	snip.rv = "moduleName"
-# `
-# endsnippet
+snippet /m "NGDoc Method" !b
+/**
+ * @ngdoc
+ * @methodOf ${1:`!p get_ng_component_of(snip)`}
+ * @name $1#${2:name}
+ * @description ${0:$1 is a method to...}
+ */
+endsnippet
 
-# vim:ft=snippets:
+snippet /p "NGDoc Property" !b
+/**
+ * @ngdoc
+ * @propertyOf ${1:`!p get_ng_component_of(snip)`}
+ * @name $1#${2:name}
+ * @description ${0:$1 is a property for ...}
+ */
+endsnippet
+
+snippet /d "NGDoc directive" !b
+/**
+ * @ngdoc directive
+ * @name $1#${2:name}
+ * @description ${0:Description}
+ * @restrict ECA
+ */
+endsnippet

--- a/UltiSnips/javascript/angular_js.snippets
+++ b/UltiSnips/javascript/angular_js.snippets
@@ -269,3 +269,5 @@ snippet /d "NGDoc directive" !b
  * @restrict ECA
  */
 endsnippet
+
+# vim:ft=snippets:

--- a/UltiSnips/javascript/angular_js.snippets
+++ b/UltiSnips/javascript/angular_js.snippets
@@ -237,7 +237,7 @@ snippet /s "NGDoc service" !b
 /**
  * @ngdoc service
  * @name ${1:`!p get_ng_module(snip)`}.service:${2:serviceName}
- * @description ${0: $2 is a service to do $2}
+ * @description ${0: \`$2\` is a service to do $2}
  */
 endsnippet
 
@@ -245,7 +245,7 @@ snippet /c "NGDoc service" !b
 /**
  * @ngdoc controller
  * @name ${1:`!p get_ng_module(snip)`}.controller:${2:controllerName}
- * @description ${0: $2 is a controller to do $2}
+ * @description ${0: \`$2\` is a controller to do $2}
  */
 endsnippet
 
@@ -254,7 +254,7 @@ snippet /m "NGDoc Method" !b
  * @ngdoc
  * @methodOf ${1:`!p get_ng_component_of(snip)`}
  * @name $1#${2:name}
- * @description ${0:$1 is a method to...}
+ * @description ${0:\`$2\` is a method to...}
  */
 endsnippet
 
@@ -263,7 +263,7 @@ snippet /p "NGDoc Property" !b
  * @ngdoc
  * @propertyOf ${1:`!p get_ng_component_of(snip)`}
  * @name $1#${2:name}
- * @description ${0:$1 is a property for ...}
+ * @description ${0:\`$2\` is a property for}
  */
 endsnippet
 
@@ -274,6 +274,14 @@ snippet /d "NGDoc directive" !b
  * @description ${0:Description}
  * @restrict ECA
  */
+endsnippet
+
+snippet */ex "Example comment" 
+* @example
+* <example>
+*   <file name="${1:index.html}">
+* 	</file>
+* </example>
 endsnippet
 
 # vim:ft=snippets:

--- a/UltiSnips/javascript/angular_js.snippets
+++ b/UltiSnips/javascript/angular_js.snippets
@@ -1,11 +1,20 @@
-
-
 snippet ngc "Define a new Angular Controller. You can change the controller name and parameters."
-var ${1:controllerName} = function(${2:scope}, ${3:injectables}) {
-  $0
-};
-endsnippet
+angular.module('`!p
+f = open(fn, 'r').read()
 
+# Regex to find module name
+mod = re.compile('angular.module\((?:\'|,")(.*?)(?:\'|")')
+
+matches = mod.findall(f)
+
+if len(matches):
+	snip.rv = matches[0]
+else:
+	snip.rv = "moduleName"
+`').controller('${1:controllerName}', function(${2:$scope}){
+	${0:$scope.awesomeThings = ['vim', 'ultisnips', 'python'];}
+});
+endsnippet
 
 snippet ngfor "angular.foreach loop"
 angular.forEach(${1:iterateOver}, function(value, key) {
@@ -174,5 +183,30 @@ snippet ngdl "A directive with a linking function only."
 });
 endsnippet
 
+snippet hget "$http.get" !b
+$http.get('${1:/uri}'${3:, ${2:query}})
+	.success(function(${4:collection}) {
+		${5:$scope.$4 = $4;}
+	})
+	.error(function(err) {
+		${6:console.log(err);}
+	})
+endsnippet
+
+# snippet /meth "Method" !b
+# `!p
+# f = open(fn, 'r').read()
+
+# # Regex to find module name
+# mod = re.compile('angular.module\((?:\'|,")(.*?)(?:\'|")')
+
+# matches = mod.findall(f)
+
+# if len(matches):
+# 	snip.rv = matches[0]
+# else:
+# 	snip.rv = "moduleName"
+# `
+# endsnippet
 
 # vim:ft=snippets:

--- a/UltiSnips/javascript/angular_js.snippets
+++ b/UltiSnips/javascript/angular_js.snippets
@@ -236,16 +236,16 @@ endsnippet
 snippet /s "NGDoc service" !b
 /**
  * @ngdoc service
- * @name ${1:`!p get_ng_module(snip)`}.service:${2:serviceName}
- * @description ${0: \`$2\` is a service to do $2}
+ * @name ${1:`!p get_ng_module(snip)`}.service:${2:`!p get_ng_component(snip)`}
+ * @description \`$2\` is a service ${0:to do $2}
  */
 endsnippet
 
 snippet /c "NGDoc service" !b
 /**
  * @ngdoc controller
- * @name ${1:`!p get_ng_module(snip)`}.controller:${2:controllerName}
- * @description ${0: \`$2\` is a controller to do $2}
+ * @name ${1:`!p get_ng_module(snip)`}.controller:${2:`!p get_ng_component(snip)`}
+ * @description \`$2\` is a controller ${0:to do $2}
  */
 endsnippet
 
@@ -270,7 +270,8 @@ endsnippet
 snippet /d "NGDoc directive" !b
 /**
  * @ngdoc directive
- * @name $1#${2:name}
+ * @name ${1:`!p get_ng_module(snip)`.directive:`!p get_ng_component(snip)`}
+ * @param {${2: Type}} ${3: name} ${4: description}
  * @description ${0:Description}
  * @restrict ECA
  */

--- a/UltiSnips/javascript/angular_js.snippets
+++ b/UltiSnips/javascript/angular_js.snippets
@@ -8,10 +8,10 @@ component_re = re.compile('\.(?:controller|directive|service|factory|provider)\(
 DEFAULT_NAME = 'appName'
 DEFAULT_TYPE_NAME = 'type'
 DEFAULT_COMPONENT_NAME = 'componentName'
-READ_BYTES=400
+CHECK_LINES=20
 
 def bufText():
-	return '\n'.join(vim.current.window.buffer[:2])
+	return '\n'.join(vim.current.window.buffer[:CHECK_LINES])
 
 def get_ng_component_of(snip):
     text = bufText()
@@ -45,6 +45,12 @@ def get_ng_module(snip, **kwargs):
     else:
         snip.rv += DEFAULT_NAME
 endglobal
+
+snippet ngc "Define a new Angular Controller. You can change the controller name and parameters."
+var ${1:controllerName} = function(${2:\$scope}, ${3:injectables}) {
+  $0
+};
+endsnippet
 
 snippet ngfor "angular.foreach loop"
 angular.forEach(${1:iterateOver}, function(value, key) {


### PR DESCRIPTION
I added a couple snippets that make documenting my code *so* much less painful. I thought they might be useful for others out there.

Additionally, the python functions are probably useful for even more smart goodness in the existing snippets but I haven't taken the time to go through those yet.