### PR TITLE
use $0 for last stop postion in snippets

### DIFF
--- a/snippets/coffee/angular_coffee.snippets
+++ b/snippets/coffee/angular_coffee.snippets
@@ -3,47 +3,47 @@
 # You can change the controller name and parameters
 snippet ngc
 	${1:controllerName} = (${2:scope}, ${3:injectables}) ->
-		${4}
+		${0}
 # angular.foreach loop
 snippet ngfor
 	angular.forEach ${1:iterateOver}, (value, key) ->
-		${2}
+		${0}
 ## Module Based Snippets
 # A new angular module without a config function
 snippet ngm
 	angular.module '${1:moduleName}', [${2:moduleDependencies}]
-	${3}
+	${0}
 # A new angular module without a config function and a variable assignment
 snippet ngma
 	${1:moduleName} = angular.module '$1', [${2:moduleDeps}]
-	${3}
+	${0}
 # A new angular module with a config function
 snippet ngmc
 	${1:moduleName} = angular.module('$1', [${2:moduleDeps}], (${3:configDeps}) ->
-		${4}
+		${0}
 	)
 # A factory in a module
 snippet ngmfa
 	factory '${1:factoryName}', (${2:dependencies}) ->
-		${3}
+		${0}
 # Define an Angular Module Service to be attached to a previously defined module
 # You can change the service name and service injectables
 snippet ngms
 	service '${1:serviceName}', (${2:injectables}) ->
-		${3}
+		${0}
 # Define an Angular Module Filter to be attached to a previously defined module
 # You can change the filter name
 snippet ngmfi
 	filter '${1:filterName}', (${2:injectables}) ->
 		(input, ${3:args}) ->
-			${4}
+			${0}
 ## Route Based Snippets
 # Defines a when condition of an AngularJS route
 snippet ngrw
 	$routeProvider.when '${1:url}',
 		templateUrl: '${2:templateUrl}'
 		controller: '${3:controller}'
-	${4}
+	${0}
 # Defines a when condition of an AngularJS route with the resolve block
 snippet ngrwr
 	$routeProvider.when '${1:url}',
@@ -51,55 +51,55 @@ snippet ngrwr
 		controller: '${3:controller}'
 		resolve:
 			${4}
-	${5}
+	${0}
 # Defines an otherwise condition of an AngularJS route
 snippet ngro
 	$routeProvider.otherwise redirectTo: '${1:url}'
-	${2}
+	${0}
 ## Scope Related Snippets
 # Define a new $scope'd function (usually inside an AngularJS Controller)
 # You can change the function name and arguments
 snippet $f
 	$scope.${1:functionName} = (${2:args}) ->
-		${3}
+		${0}
 # Defines a new $scope'd variable inside an AngularJS controller
 snippet $v
 	$scope.${1:variable} = ${2:value}
-	${3}
+	${0}
 # Defines a new $scope'd variable inside an AngularJS controller and assigns a value from a constructor arguments
 snippet $va
 	$scope.${1:variable} = ${2:variable}
-	${3}
+	${0}
 # Define a $watch for an expression
 # You can change the expression to be watched
 snippet $w
 	$scope.$watch '${1:watchExpr}', (newValue, oldValue) ->
-		${2}
+		${0}
 # Define a $on for a $broadcast/$emit on the $scope inside an Angular Controller
 # You can change the event name to listen on
 snippet $on
 	$scope.$on '${1:eventName}', (event, ${2:args}) ->
-		${3}
+		${0}
 # Define a $broadcast for a $scope inside an Angular Controller / Angular Controller Function
 # You can change the event name and optional event arguments
 snippet $b
 	$scope.$broadcast '${1:eventName}', ${2:eventArgs}
-	${3}
+	${0}
 # Define an $emit for a $scope inside an Angular Controller / Angular Controller Function
 # You can change the event name and optional event arguments
 snippet $e
 	$scope.$emit '${1:eventName}', ${2:eventArgs}
-	${3}
+	${0}
 ## Directive related snippets
 # A compile function
 snippet ngdcf
 	compile = (tElement, tAttrs, transclude) ->
 		(scope, element, attrs) ->
-			${1}
+			${0}
 # A linking function in a directive
 snippet ngdlf
 	(scope, element, attrs${1:ctrl}) ->
-		${2}
+		${0}
 # A directive with a compile function
 snippet ngdc
 	directive '${1:directiveName}', factory = (${2:injectables}) ->
@@ -107,10 +107,11 @@ snippet ngdc
 			${3:directiveAttrs}
 			compile: compile = (tElement, tAttrs, transclude) ->
 				(scope, element, attrs) ->
+					${0}
 		directiveDefinitionObject
 # A directive with a linking function only
 snippet ngdl
 	.directive('${1:directiveName}', (${2:directiveDeps}) ->
 		(scope, element, attrs${3:ctrl}) ->
-			${4}
+			${0}
 	)

--- a/snippets/haml/angular_haml.snippets
+++ b/snippets/haml/angular_haml.snippets
@@ -2,23 +2,23 @@
 snippet ngindex
 	%html
 		%head
-			%script{:src => "https://ajax.googleapis.com/ajax/libs/angularjs/${1:1.2.12}/angular.js"}
+			%script{:src => "https://ajax.googleapis.com/ajax/libs/angularjs/${1:1.6.3}/angular.js"}
 		%body{"ng-app" => true}
-			${2}
+			${0}
 # Script tag importing base AngularJS file from CDN
 snippet ngsa
-	%script{:src => "https://ajax.googleapis.com/ajax/libs/angularjs/${1:1.2.12}/angular.js"}
-	${2}
+	%script{:src => "https://ajax.googleapis.com/ajax/libs/angularjs/${1:1.6.3}/angular.js"}
+	${0}
 # A script tag holding Angular's template
 snippet ngst
 	%script{:type => "text/ng-template", :id => "${1:id}"}
-		${2}
+		${0}
 # A binding in AngularJS
 snippet ngb
-	{{${1:binding}}}${2}
+	{{${1:binding}}}
 # Bind a view to a model
 snippet ngm
 	ng-model="${1:model}"
 # Disable a form element
-snippet ngd 
+snippet ngd
 	ng-disabled="${1:model}"

--- a/snippets/html/angular_html.snippets
+++ b/snippets/html/angular_html.snippets
@@ -2,32 +2,32 @@
 snippet ngindex
 	<html>
 	<head>
-		<script src="https://ajax.googleapis.com/ajax/libs/angularjs/${1:1.2.12}/angular.js"></script>
+		<script src="https://ajax.googleapis.com/ajax/libs/angularjs/${1:1.6.3}/angular.js"></script>
 	</head>
 	<body ng-app>
 
-	${2}
+	${0}
 
 	</body>
 	</html>
 # Script tag importing base AngularJS file from CDN
 snippet ngsa
-	<script src="https://ajax.googleapis.com/ajax/libs/angularjs/${1:1.2.12}/angular.js"></script>
+	<script src="https://ajax.googleapis.com/ajax/libs/angularjs/${1:1.6.3}/angular.js"></script>
 
-	${2}
+	${0}
 # A script tag holding Angular's template
 snippet ngst
 	<script type="text/ng-template" id="${1:id}">
-	${2}
+	${0}
 	</script>
 # A binding in AngularJS
 snippet ngb
-	{{${1:binding}}}${2}
+	{{${1:binding}}}
 # Bind a view to a model
 snippet ngm
 	ng-model="${1:model}"
 # Disable a form element
-snippet ngd 
+snippet ngd
 	ng-disabled="${1:model}"
 # Conditionally render an element
 snippet ngi

--- a/snippets/javascript/angular_js.snippets
+++ b/snippets/javascript/angular_js.snippets
@@ -3,44 +3,44 @@
 # You can change the controller name and parameters
 snippet ngc
 	var ${1:controllerName} = function(${2:scope}, ${3:injectables}) {
-		${4}
+		${0}
 	};
 # angular.foreach loop
 snippet ngfor
 	angular.forEach(${1:iterateOver}, function(value, key) {
-		${2}
+		${0}
 	});
 ## Module Based Snippets
 # A new angular module without a config function
 snippet ngm
 	angular.module('${1:moduleName}', [${2:moduleDependencies}]);
-	${3}
+	${0}
 # A new angular module without a config function and a variable assignment
 snippet ngma
 	var ${1:moduleName} = angular.module('$1', [${2:moduleDeps}]);
-	${3}
+	${0}
 # A new angular module with a config function
 snippet ngmc
 	var ${1:moduleName} = angular.module('$1', [${2:moduleDeps}], function(${3:configDeps}) {
-		${4}
+		${0}
 	});
 # A factory in a module
 snippet ngmfa
 	factory('${1:factoryName}', function(${2:dependencies}) {
-		${3}
+		${0}
 	});
 # Define an Angular Module Service to be attached to a previously defined module
 # You can change the service name and service injectables
 snippet ngms
 	service('${1:serviceName}', function(${2:injectables}) {
-		${3}
+		${0}
 	});
 # Define an Angular Module Filter to be attached to a previously defined module
 # You can change the filter name
 snippet ngmfi
 	filter('${1:filterName}', function(${2:injectables}) {
 		return function(input, ${3:args}) {
-			${4}
+			${0}
 		};
 	});
 ## Route Based Snippets
@@ -50,7 +50,7 @@ snippet ngrw
 		templateUrl: '${2:templateUrl}',
 		controller: '${3:controller}'
 	});
-	${4}
+	${0}
 # Defines a when condition of an AngularJS route with the resolve block
 snippet ngrwr
 	$routeProvider.when('${1:url}', {
@@ -60,62 +60,62 @@ snippet ngrwr
 			${4}
 		}
 	});
-	${5}
+	${0}
 # Defines an otherwise condition of an AngularJS route
 snippet ngro
 	$routeProvider.otherwise({
 		redirectTo: '${1:url}'
 	});
-	${2}
+	${0}
 ## Scope Related Snippets
 # Define a new $scope'd function (usually inside an AngularJS Controller)
 # You can change the function name and arguments
 snippet $f
 	$scope.${1:functionName} = function(${2:args}) {
-		${3}
+		${0}
 	};
 # Defines a new $scope'd variable inside an AngularJS controller
 snippet $v
 	$scope.${1:variable} = ${2:value};
-	${3}
+	${0}
 # Defines a new $scope'd variable inside an AngularJS controller and assigns a value from a constructor arguments
 snippet $va
 	$scope.${1:variable} = ${2:variable};
-	${3}
+	${0}
 # Define a $watch for an expression
 # You can change the expression to be watched
 snippet $w
 	$scope.$watch('${1:watchExpr}', function(newValue, oldValue) {
-		${2}
+		${0}
 	});
 # Define a $on for a $broadcast/$emit on the $scope inside an Angular Controller
 # You can change the event name to listen on
 snippet $on
 	$scope.$on('${1:eventName}', function(event, ${2:args}) {
-		${3}
+		${0}
 	});
 # Define a $broadcast for a $scope inside an Angular Controller / Angular Controller Function
 # You can change the event name and optional event arguments
 snippet $b
 	$scope.$broadcast('${1:eventName}', ${2:eventArgs});
-	${3}
+	${0}
 # Define an $emit for a $scope inside an Angular Controller / Angular Controller Function
 # You can change the event name and optional event arguments
 snippet $e
 	$scope.$emit('${1:eventName}', ${2:eventArgs});
-	${3}
+	${0}
 ## Directive related snippets
 # A compile function
 snippet ngdcf
 	function compile(tElement, tAttrs, transclude) {
 		return function(scope, element, attrs) {
-			${1}
+			${0}
 		}
 	}
 # A linking function in a directive
 snippet ngdlf
 	function(scope, element, attrs${1:ctrl}) {
-		${2}
+		${0}
 	}
 # A directive with a compile function
 snippet ngdc
@@ -124,7 +124,7 @@ snippet ngdc
 			${3:directiveAttrs},
 			compile: function compile(tElement, tAttrs, transclude) {
 				return function (scope, element, attrs) {
-				
+					${0}
 				}
 			}
 		};
@@ -134,6 +134,6 @@ snippet ngdc
 snippet ngdl
 	.directive('${1:directiveName}', function(${2:directiveDeps}) {
 		return function(scope, element, attrs${3:ctrl}) {
-			${4}
+			${0}
 		}
 	});


### PR DESCRIPTION
I've made the following improvement:
- Replace the last stop position by `${0}` in snipMate snippets.
- Remove a few unnecessary stop positions (e.g. {{${1:binding}}} `${2}`)
- Update angularJS version to 1.6.3 in snippets
- Add last stop position to `ngdc` snippets

All these changes have passed my manual tests.